### PR TITLE
v1.3.0 update to Factorio 0 15.34

### DIFF
--- a/info.json
+++ b/info.json
@@ -1,10 +1,10 @@
 {
   "name": "MoreLogisticsSlots",
-  "version": "1.2.0",
+  "version": "2.0",
   "title": "More logistics slots",
   "author": "Wenihal. Updated by JoCkeR-il for 0.12 and up",
   "homepage": "https://github.com/jocker-il",
-  "factorio_version": "0.14",  
+  "factorio_version": "0.15",  
   "dependencies": ["base"],
-  "description": "Adds more character logistics slots (up to 10 slots)"
+  "description": "Adds more character logistics slots (up to 10 slots). Reworked for 0.15, since the change to the science packs"
 }


### PR DESCRIPTION
v1.3.0 - Updated for Factorio 0.15.x (tested on 0.15.34)
 
 - Changed "info.json" file
 - All recipes updated to the new science packs
 - Removed level 6 since it's in the game
